### PR TITLE
Sedivy/remove cors from privs blueprint

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,1 +1,1 @@
-yuanzhou/docker-tweaks:f0010ef
+blueprint:fdb45dd

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Only root can listen on ports below 1024, we use higher-numbered ports
     # since nginx is running under non-root user hubmap
     ports:
-      - "8484:8080"
+      - "5555:8080"
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:8080"]
       interval: 1m30s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,8 +24,7 @@ services:
     restart: always
     volumes:
       # Mount the app config to container in order to keep it outside of the image
-#      - "../src/instance:/usr/src/app/src/instance"
-      - "../src:/usr/src/app/src"
+      - "../src/instance:/usr/src/app/src/instance"
       # Mount the logging to container
       - "../log:/usr/src/app/log"
       # Mount conf.d on host machine to the nginx conf.d on container

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # Only root can listen on ports below 1024, we use higher-numbered ports
     # since nginx is running under non-root user hubmap
     ports:
-      - "5555:8080"
+      - "8484:8080"
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:8080"]
       interval: 1m30s
@@ -24,7 +24,8 @@ services:
     restart: always
     volumes:
       # Mount the app config to container in order to keep it outside of the image
-      - "../src/instance:/usr/src/app/src/instance"
+#      - "../src/instance:/usr/src/app/src/instance"
+      - "../src:/usr/src/app/src"
       # Mount the logging to container
       - "../log:/usr/src/app/log"
       # Mount conf.d on host machine to the nginx conf.d on container

--- a/src/app.py
+++ b/src/app.py
@@ -7,7 +7,6 @@ import argparse
 from shutil import rmtree # Used by file removal
 from flask import Flask, jsonify, abort, request, session, redirect, Response
 from globus_sdk import AccessTokenAuthorizer, AuthClient, ConfidentialAppAuthClient
-from flask_cors import CORS
 
 # HuBMAP commons
 from hubmap_commons.hm_auth import AuthHelper
@@ -26,9 +25,6 @@ logger = logging.getLogger(__name__)
 # Specify the absolute path of the instance folder and use the config file relative to the instance path
 app = Flask(__name__, instance_path=os.path.join(os.path.abspath(os.path.dirname(__file__)), 'instance'), instance_relative_config=True)
 app.config.from_pyfile('app.cfg')
-
-# https://stackoverflow.com/questions/66042805/flask-cors-stopped-allowing-access-to-resources
-cors = CORS(app, resources={r"/*": {"origins": "*"}})
 
 app.register_blueprint(auth_blueprint)
 app.register_blueprint(status_blueprint)

--- a/src/routes/privs/__init__.py
+++ b/src/routes/privs/__init__.py
@@ -1,14 +1,13 @@
-from flask import Blueprint, session, make_response, jsonify
-from flask_cors import cross_origin
 import logging
 
+from flask import Blueprint, make_response, jsonify
 from hubmap_commons.hm_auth import AuthHelper
 
 privs_blueprint = Blueprint('privs', __name__)
 logger = logging.getLogger(__name__)
 
 
-@cross_origin()
+
 @privs_blueprint.route('/privs/for_groups_token/<groups_token>')
 def privs_for_groups_token(groups_token: str):
     auth_helper_instance: AuthHelper = AuthHelper.instance()


### PR DESCRIPTION
Removed CORS from the /privs endpoints because it is configured in the nginx container. See /docker/ingest-api/nginx/conf.d/entity-api.conf