### PR TITLE
Fix entity_CRUD module import

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A restful web service exposing calls needed for the [Portal UI](https://github.com/sennetconsortium/portal-ui) Next.js application. The API is documented [here](https://smart-api.info/registry?q=@todo).
 
+## PyCharm configuration
+Right click the ***src*** folder and select *Mark directory as > sources root*
+You should see the ***src*** folder turn blue
+
 ## Flask app configuration
 
 This application is written in Flask and it includes an **app.cfg.example** file in the `instance` directory.  Copy the file and rename it **app.cfg** and modify  with the appropriate information.

--- a/docker/ingest-api/Dockerfile
+++ b/docker/ingest-api/Dockerfile
@@ -42,7 +42,8 @@ RUN yum install -y yum-utils && \
     rm -rf nginx && \
     pip install --upgrade pip -r src/requirements.txt && \
     chmod +x start.sh && \
-    yum clean all 
+    yum clean all && \
+    echo 'export PYTHONPATH="/usr/src/app:${PYTHONPATH}"' > ~/.bash_rc
 
 # The EXPOSE instruction informs Docker that the container listens on the specified network ports at runtime. 
 # EXPOSE does not make the ports of the container accessible to the host.

--- a/docker/ingest-api/Dockerfile
+++ b/docker/ingest-api/Dockerfile
@@ -42,8 +42,7 @@ RUN yum install -y yum-utils && \
     rm -rf nginx && \
     pip install --upgrade pip -r src/requirements.txt && \
     chmod +x start.sh && \
-    yum clean all && \
-    echo 'export PYTHONPATH="/usr/src/app:${PYTHONPATH}"' > ~/.bash_rc
+    yum clean all
 
 # The EXPOSE instruction informs Docker that the container listens on the specified network ports at runtime. 
 # EXPOSE does not make the ports of the container accessible to the host.

--- a/docker/ingest-api/entrypoint.sh
+++ b/docker/ingest-api/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source ~/.bash_rc
+
 # Pass the HOST_UID and HOST_UID from environment variables specified in the child image docker-compose
 HOST_GID=${HOST_GID}
 HOST_UID=${HOST_UID}

--- a/docker/ingest-api/entrypoint.sh
+++ b/docker/ingest-api/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+source ~/.bash_rc
 # Pass the HOST_UID and HOST_UID from environment variables specified in the child image docker-compose
 HOST_GID=${HOST_GID}
 HOST_UID=${HOST_UID}

--- a/src/routes/entity_CRUD/__init__.py
+++ b/src/routes/entity_CRUD/__init__.py
@@ -10,7 +10,7 @@ entity_CRUD_blueprint = Blueprint('entity_CRUD', __name__)
 logger = logging.getLogger(__name__)
 
 # Local modules
-from src.routes.entity_CRUD.ingest_file_helper import IngestFileHelper
+from routes.entity_CRUD.ingest_file_helper import IngestFileHelper
 
 @entity_CRUD_blueprint.route('/datasets', methods=['POST'])
 def create_dataset():


### PR DESCRIPTION
The container fails to start with this stack trace 

Traceback (most recent call last):
  File "/usr/src/app/src/./wsgi.py", line 1, in <module>
    from app import app as application
  File "/usr/src/app/src/./app.py", line 17, in <module>
    from routes.entity_CRUD import entity_CRUD_blueprint
  File "/usr/src/app/src/./routes/entity_CRUD/__init__.py", line 13, in <module>
    from src.routes.entity_CRUD.ingest_file_helper import IngestFileHelper
ModuleNotFoundError: No module named 'src'

