### PR TITLE
Add support for split up abstract fields: purpose, method and result …

### DIFF
--- a/src/routes/entity_CRUD/__init__.py
+++ b/src/routes/entity_CRUD/__init__.py
@@ -1679,7 +1679,7 @@ def append_constraints_list(entity_to_validate, ancestor_dict, header, entity_co
     url = commons_file_helper.ensureTrailingSlashURL(current_app.config['ENTITY_WEBSERVICE_URL']) + 'entities/' + ancestor_id
 
     resp = requests.get(url, headers=header)
-    if resp.status_code > 200:
+    if not resp.ok:
         err = resp.json()
         err_msg = err.get('error') if 'error' in err else err
         raise Exception(f"{err_msg}")


### PR DESCRIPTION
Change log:
1. Add support for doi abstract parts `purpose`, `method` and `result`
2. Add `raise Exception` in order to catch entity api related error responses

Requires: 
https://github.com/sennetconsortium/entity-api/pull/234
https://github.com/sennetconsortium/entity-api/pull/234/commits/6c6cfe6a73a21a0fd064b12df3c6747cc63f8d07