### PR TITLE
Clearing pipeline data when dataset is processing

### DIFF
--- a/src/routes/entity_CRUD/tasks.py
+++ b/src/routes/entity_CRUD/tasks.py
@@ -13,7 +13,15 @@ def submit_datasets(dataset_uuids: list, token: str, config: dict):
     entity_api_url = config["ENTITY_WEBSERVICE_URL"]
 
     # change the status of the datasets to Processing using entity-api
-    update_payload = {uuid: {"status": "Processing"} for uuid in dataset_uuids}
+    update_payload = {
+        uuid: {
+            "status": "Processing",
+            "ingest_id": "",
+            "run_id": "",
+            "pipeline_message": "",
+        }
+        for uuid in dataset_uuids
+    }
     update_status_res = bulk_update_entities(
         update_payload, token, entity_api_url=entity_api_url
     )


### PR DESCRIPTION
This commit sets the dataset's ingest_id, run_id, and pipeline_message to an empty string when the datasets is processing. This accounts for the case when a dataset is resubmitted.