### PR TITLE
Libpitt/485 fileperm

### DIFF
--- a/src/instance/app.cfg.example
+++ b/src/instance/app.cfg.example
@@ -34,11 +34,6 @@ GLOBUS_CLIENT_APP_URI = 'https://data.dev.sennetconsortium.org/'
 DATA_INGEST_BOARD_APP_URI = 'http://localhost:3001/'
 DATA_INGEST_BOARD_NAME = ‘Data Ingest Board - DEV’
 
-GLOBUS_BASE_FILE_USER_NAME = 'hive'
-GLOBUS_ADMIN_FILE_USER_NAME = 'shirey'
-GLOBUS_GENOMIC_DATA_FILE_GROUP_NAME = 'hubseq'
-GLOBUS_CONSORTIUM_FILE_GROUP_NAME = 'hubmap'
-
 #Sets the domain for the cookie set upon login to the portal. Use `localhost` for local development
 COOKIE_DOMAIN = '.sennetconsortium.org'
 

--- a/src/lib/ingest_file_helper.py
+++ b/src/lib/ingest_file_helper.py
@@ -29,7 +29,8 @@ class IngestFileHelper:
 
     def get_dataset_directory_absolute_path(self, dataset_record, group_uuid, dataset_uuid):
         if 'contains_human_genetic_sequences' not in dataset_record:
-            self.logger.info(f"get_dataset_directory_absolute_path: contains_human_genetic_sequences is None {dataset_uuid}")
+            self.logger.info(
+                f"get_dataset_directory_absolute_path: contains_human_genetic_sequences is None {dataset_uuid}")
 
         if 'contains_human_genetic_sequences' in dataset_record and dataset_record['contains_human_genetic_sequences']:
             access_level = self.appconfig['ACCESS_LEVEL_PROTECTED']
@@ -60,7 +61,8 @@ class IngestFileHelper:
 
     def get_dataset_directory_relative_path(self, dataset_record, group_uuid, dataset_uuid):
         if 'contains_human_genetic_sequences' not in dataset_record:
-            self.logger.info(f"get_dataset_directory_relative_path: contains_human_genetic_sequences is None {dataset_uuid}")
+            self.logger.info(
+                f"get_dataset_directory_relative_path: contains_human_genetic_sequences is None {dataset_uuid}")
 
         if 'contains_human_genetic_sequences' in dataset_record and dataset_record['contains_human_genetic_sequences']:
             access_level = 'protected'
@@ -82,15 +84,17 @@ class IngestFileHelper:
         grp_name = AuthHelper.getGroupDisplayName(group_uuid)
         if access_level == 'protected':
             endpoint_id = self.appconfig['GLOBUS_PROTECTED_ENDPOINT_UUID']
-            rel_path = str(os.path.join(self.appconfig['RELATIVE_GLOBUS_PROTECTED_ENDPOINT_FILEPATH'], grp_name, dataset_uuid))
+            rel_path = str(
+                os.path.join(self.appconfig['RELATIVE_GLOBUS_PROTECTED_ENDPOINT_FILEPATH'], grp_name, dataset_uuid))
         elif published:
             endpoint_id = self.appconfig['GLOBUS_PUBLIC_ENDPOINT_UUID']
             rel_path = str(os.path.join(self.appconfig['RELATIVE_GLOBUS_PUBLIC_ENDPOINT_FILEPATH'], dataset_uuid))
         else:
             endpoint_id = self.appconfig['GLOBUS_CONSORTIUM_ENDPOINT_UUID']
-            rel_path = str(os.path.join(self.appconfig['RELATIVE_GLOBUS_CONSORTIUM_ENDPOINT_FILEPATH'], grp_name, dataset_uuid))
+            rel_path = str(
+                os.path.join(self.appconfig['RELATIVE_GLOBUS_CONSORTIUM_ENDPOINT_FILEPATH'], grp_name, dataset_uuid))
 
-        return {"rel_path":rel_path, "globus_endpoint_uuid":endpoint_id}
+        return {"rel_path": rel_path, "globus_endpoint_uuid": endpoint_id}
 
     def create_dataset_directory(self, dataset_record, group_uuid, dataset_uuid):
         try:
@@ -129,20 +133,24 @@ class IngestFileHelper:
 
     def set_dir_permissions(self, access_level, file_path, published=False, trial_run=False):
         try:
-            mode = 0o750  #rwxr-x---
+
+            mode = 0o750  # rwxr-x---
             if not published:
                 if access_level == self.appconfig['ACCESS_LEVEL_PUBLIC']:
-                    mode = 0o755  #rwxr-xr-x
+                    mode = 0o755  # rwxr-xr-x
             else:
-                mode = 0o550
+                mode = 0o550  # r-xr-x---
                 if access_level == self.appconfig['ACCESS_LEVEL_PUBLIC']:
-                    mode = 0o555  #r-xr-xr-x
+                    mode = 0o555  # r-xr-xr-x
 
-            # apply the permissions
+            # since mode value is octal literal, let's get its string representation removing the proceeding 0o
+            octal_representation = oct(mode)[2:]
             # put quotes around the path since it often contains spaces
-            chmod_command = f"chmod {mode} {file_path}"
-            self.logger.info(f"Executing chnod with mode: {mode} and permissions {self.appconfig['ACCESS_LEVEL_PUBLIC']}")
+            chmod_command = f"chmod {octal_representation} '{file_path}'"
+            self.logger.info(
+                f"Executing chmod with mode: {octal_representation} and permissions {self.appconfig['ACCESS_LEVEL_PUBLIC']}")
             if not trial_run:
+                # apply the permissions
                 os.chmod(file_path, mode)
             else:
                 print(chmod_command)

--- a/src/lib/ingest_file_helper.py
+++ b/src/lib/ingest_file_helper.py
@@ -148,7 +148,7 @@ class IngestFileHelper:
             # put quotes around the path since it often contains spaces
             chmod_command = f"chmod {octal_representation} '{file_path}'"
             self.logger.info(
-                f"Executing chmod with mode: {octal_representation} and permissions {self.appconfig['ACCESS_LEVEL_PUBLIC']}")
+                f"Executing chmod with mode: {octal_representation} and permissions {access_level}")
             if not trial_run:
                 # apply the permissions
                 os.chmod(file_path, mode)

--- a/src/lib/ingest_file_helper.py
+++ b/src/lib/ingest_file_helper.py
@@ -136,7 +136,7 @@ class IngestFileHelper:
 
             mode = 0o750  # rwxr-x---
             if not published:
-                if access_level == self.appconfig['ACCESS_LEVEL_PUBLIC']:
+                if access_level in [self.appconfig['ACCESS_LEVEL_PUBLIC'], self.appconfig['ACCESS_LEVEL_CONSORTIUM']]:
                     mode = 0o755  # rwxr-xr-x
             else:
                 mode = 0o550  # r-xr-x---


### PR DESCRIPTION
Change log:
1. Use `chmod` instead of `setfacl` command for non AWS server.
2. Remove unused GLOBUS_ app.cfg.example values

Updated method here: https://github.com/sennetconsortium/ingest-api/blob/b79d5378f73fa404ddc5daa5e6015f1903f28bb4/src/lib/ingest_file_helper.py#L134-L157

(For security reasons, the method assumes protect first, grant access after. So protected modes are default, public the after thought. Similar to login scenarios where assume no access unless correctly authenticated.)