### PR TITLE
Changing status to return 500 if any check fails

### DIFF
--- a/src/routes/status/__init__.py
+++ b/src/routes/status/__init__.py
@@ -1,6 +1,4 @@
-import json
-
-from flask import Blueprint, current_app, Response, request
+from flask import Blueprint, current_app, jsonify, request
 from pathlib import Path
 import logging
 
@@ -44,14 +42,9 @@ def get_status():
         # check the neo4j connection
         try:
             with Neo4jHelper.get_instance().session() as session:
-                recds = session.run("Match () Return 1 Limit 1")
-                for recd in recds:
-                    if recd[0] == 1:
-                        is_connected = True
-                    else:
-                        is_connected = False
+                res = session.run("MATCH () RETURN TRUE AS connected LIMIT 1").single()
+                is_connected = res['connected']
 
-                is_connected = True
         # the neo4j connection will often fail via exception so
         # catch it here, flag as failure and track the returned error message
         except Exception as e:
@@ -87,4 +80,4 @@ def get_status():
         response_code = 500
         response_data['exception_message'] = str(e)
     finally:
-        return Response(json.dumps(response_data), response_code, mimetype='application/json')
+        return jsonify(response_data), response_code

--- a/src/routes/status/__init__.py
+++ b/src/routes/status/__init__.py
@@ -22,41 +22,39 @@ json
 def get_status():
     try:
         response_code = 200
-
         response_data = {
             # Use strip() to remove leading and trailing spaces, newlines, and tabs
             'version': (Path(__file__).absolute().parent.parent.parent.parent / 'VERSION').read_text().strip(),
-            'build': (Path(__file__).absolute().parent.parent.parent.parent / 'BUILD').read_text().strip()
+            'build': (Path(__file__).absolute().parent.parent.parent.parent / 'BUILD').read_text().strip(),
+            'services': []
         }
 
+        # check redis connection
         if current_app.config.get("REDIS_MODE"):
             redis_connected = JobQueue.is_connected(current_app.config['REDIS_SERVER'])
-            response_data['redis_connection'] = redis_connected
+            service = {'name': 'redis', 'status': redis_connected}
             if not redis_connected:
+                service['message'] = f"Cannot connect to Redis server at {current_app.config['REDIS_SERVER']}"
                 response_code = 500
+            response_data['services'].append(service)
+
+        # check the neo4j connection
+        try:
+            service = {'name': 'neo4j', 'status': True}
+            with Neo4jHelper.get_instance().session() as session:
+                res = session.run('MATCH () RETURN TRUE AS connected LIMIT 1').single()
+                neo4j_connected = res['connected']
+                if neo4j_connected is False:
+                    raise Exception(f"Cannot connect to Neo4j server at {current_app.config['NEO4J_URI']}")
+        except Exception as e:
+            response_code = 500
+            service['status'] = False
+            service['message'] = str(e).replace("'", "")
+        response_data['services'].append(service)
 
         # if ?check-ws-dependencies=true is present in the url request params
         # set a flag to check these other web services
         check_ws_calls = string_helper.isYes(request.args.get('check-ws-dependencies'))
-
-        # check the neo4j connection
-        try:
-            with Neo4jHelper.get_instance().session() as session:
-                res = session.run("MATCH () RETURN TRUE AS connected LIMIT 1").single()
-                is_connected = res['connected']
-
-        # the neo4j connection will often fail via exception so
-        # catch it here, flag as failure and track the returned error message
-        except Exception as e:
-            response_code = 500
-            response_data['neo4j_error'] = str(e)
-            is_connected = False
-
-        if is_connected:
-            response_data['neo4j_connection'] = True
-        else:
-            response_code = 500
-            response_data['neo4j_connection'] = False
 
         # if the flag was set to check ws dependencies do it now
         # for each dependency try to connect via helper which calls the
@@ -65,19 +63,36 @@ def get_status():
         # an integer with the number of milliseconds that it took to get
         # the services status
         if check_ws_calls:
+            # check the uuid-api connection
             uuid_ws_url = current_app.config['UUID_WEBSERVICE_URL'].strip()
             uuid_ws_check = net_helper.check_hm_ws(uuid_ws_url)
-            entity_ws_check = net_helper.check_hm_ws(current_app.config['ENTITY_WEBSERVICE_URL'])
-            search_ws_check = net_helper.check_hm_ws(current_app.config['SEARCH_WEBSERVICE_URL'])
-            if not uuid_ws_check or not entity_ws_check or not search_ws_check:
+            service = {'name': 'uuid-api', 'status': True if uuid_ws_check is not False else False}
+            if uuid_ws_check is False:
+                service['message'] = f'Cannot connect to uuid-api at {uuid_ws_url}'
                 response_code = 500
-            response_data['uuid_ws'] = uuid_ws_check
-            response_data['entity_ws'] = entity_ws_check
-            response_data['search_ws_check'] = search_ws_check
+            response_data['services'].append(service)
+
+            # check the entity-api connection
+            entity_ws_url = current_app.config['ENTITY_WEBSERVICE_URL'].strip()
+            entity_ws_check = net_helper.check_hm_ws(entity_ws_url)
+            service = {'name': 'entity-api', 'status': True if entity_ws_check is not False else False}
+            if entity_ws_check is False:
+                service['message'] = f'Cannot connect to entity-api at {entity_ws_url}'
+                response_code = 500
+            response_data['services'].append(service)
+
+            # check the search-api connection
+            search_ws_url = current_app.config['SEARCH_WEBSERVICE_URL'].strip()
+            search_ws_check = net_helper.check_hm_ws(search_ws_url)
+            service = {'name': 'search-api', 'status': True if search_ws_check is not False else False}
+            if search_ws_check is False:
+                service['message'] = f'Cannot connect to search-api at {search_ws_url}'
+                response_code = 500
+            response_data['services'].append(service)
 
     # catch any unhandled exceptions
     except Exception as e:
         response_code = 500
-        response_data['exception_message'] = str(e)
+        response_data['message'] = 'An error occurred while checking the status of the services: ' + str(e)
     finally:
         return jsonify(response_data), response_code


### PR DESCRIPTION
Changes
- Return 500 from `/status` endpoint if any checks fail or any exception is raised
- Changed status response to match
```jsonc
{
    "build": "tjmadonna/dockerignore:f63535a",
    "version": "1.6.1",
    "services": [
        {
            "name": "entity-api",
            "status": true
        },
        {
            "name": "neo4j",
            "status": false,
            "message": "Cannot connect to Neo4j at bolt://neo4j:7687"
        },
        ...
    ]
}
```