### PR TITLE
Removing other organ from bulk organ validation

### DIFF
--- a/src/jobs/validation/entities.py
+++ b/src/jobs/validation/entities.py
@@ -231,7 +231,7 @@ def validate_samples(headers, records, header):
         .organ_types()
         .keys()
     )
-    organ_types_codes.append("OT")
+    organ_types_codes.remove("OT")
 
     rownum = 0
     valid_ancestor_ids = []
@@ -339,7 +339,7 @@ def validate_samples(headers, records, header):
                     file_is_valid = False
                     error_msg.append(
                         ln_err(
-                            f"value must be an organ code listed at {get_organ_types_ep()}",
+                            f"value must be an organ code listed at {get_organ_types_ep()} and not 'OT'",
                             rownum,
                             "organ_type",
                         )


### PR DESCRIPTION
Changes
- Removed `OT` from the `organ_types_codes` in bulk sample validation job